### PR TITLE
Ensure that directories always end in `'/'` for `canonical_rpaths()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/src/Abstract/DynamicLink.jl
+++ b/src/Abstract/DynamicLink.jl
@@ -130,6 +130,11 @@ function canonical_rpaths(rpath::RPath)
         paths[idx] = replace(paths[idx], "@loader_path" => origin)
         paths[idx] = replace(paths[idx], "@executable_path" => origin)
         paths[idx] = abspath(paths[idx])
+
+        # Make sure that if it's a directory, it _always_ has a "/" at the end.
+        if isdir(paths[idx]) && paths[idx][end] != '/'
+            paths[idx] = paths[idx] * "/"
+        end
     end
     return paths
 end

--- a/src/COFF/COFFDynamicLink.jl
+++ b/src/COFF/COFFDynamicLink.jl
@@ -71,5 +71,5 @@ rpaths(crp::COFFRPath) = String[]
 
 # COFF files don't have an RPath, but they _do_ always search the $ORIGIN
 function canonical_rpaths(crp::COFFRPath)
-    return [dirname(path(handle(crp)))]
+    return [abspath(dirname(path(handle(crp))) * "/")]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ function test_libfoo_and_fooifier(fooifier_path, libfoo_path)
             # Ensure that `dir_path` is one of the RPath entries
             rpath = RPath(oh_exe)
             can_paths = canonical_rpaths(rpath)
-            @test abspath(dir_path) in can_paths
+            @test abspath(dir_path * "/") in can_paths
 
             # Ensure that `fooifier` is going to try to load `libfoo`:
             foo_libs = find_libraries(oh_exe)


### PR DESCRIPTION
This is important for `BinaryBuilder` to avoid adding multiple identical rpath's to the same binary.