### PR TITLE
Force `start` field of handles to be `Int64`

### DIFF
--- a/src/COFF/COFFHandle.jl
+++ b/src/COFF/COFFHandle.jl
@@ -9,7 +9,7 @@ client applications will interact with COFF files.
 struct COFFHandle{T<:IO} <: ObjectHandle
     # Backing IOS and start point within the IOStream of this COFF object
     io::T
-    start::Int
+    start::Int64
 
     # The parsed-out header of the COFF object
     header::COFFHeader
@@ -63,7 +63,7 @@ function readmeta(io::IO, ::Type{H}) where {H <: COFFHandle}
     opt_header = read(io, COFFOptionalHeader)
 
     # Construct our COFFHandle, pilfering the filename from the IOStream
-    return COFFHandle(io, start, header, header_offset, opt_header, path(io))
+    return COFFHandle(io, Int64(start), header, header_offset, opt_header, path(io))
 end
 
 

--- a/src/ELF/ELFHandle.jl
+++ b/src/ELF/ELFHandle.jl
@@ -14,7 +14,7 @@ client applications will interact with ELF files.
 struct ELFHandle{T<:IO} <: ObjectHandle
     # Backing IOS and start point within the IOStream of this ELF object
     io::T
-    start::Int
+    start::Int64
 
     # Elf Internal data such as endianness, version, OS ABI, etc...
     ei::ELFInternal
@@ -56,7 +56,7 @@ function readmeta(io::IO, ::Type{H}) where {H <: ELFHandle}
     seek(io, start)
 
     # Construct our ELFHandle, pilfering the filename from the IOStream
-    return ELFHandle(io, start, ei, header, path(io))
+    return ELFHandle(io, Int64(start), ei, header, path(io))
 end
 
 

--- a/src/MachO/MachOHandle.jl
+++ b/src/MachO/MachOHandle.jl
@@ -3,7 +3,7 @@ export MachOHandle, FatMachOHandle
 struct MachOHandle{T <: IO} <: ObjectHandle
     # Backing IO and start point within the IOStream of this MachO object
     io::T
-    start::Int
+    start::Int64
 
     # The parsed-out header of the MachO object
     header::MachOHeader
@@ -30,7 +30,7 @@ function readmeta(io::IO,::Type{MachOHandle})
 
     # Unpack the header
     header = unpack(io, header_type, endianness)
-    return MachOHandle(io, start, header, path(io))
+    return MachOHandle(io, Int64(start), header, path(io))
 end
 
 ## IOStream-like operations:


### PR DESCRIPTION
`position(s::IOStream)` always return `Int64`, for the sake of security let’s
always use the largest type.

Fix #17.