### PR TITLE
Ignore `EOFError`'s as well as `MagicMismatchError`s

### DIFF
--- a/src/Abstract/ObjectHandle.jl
+++ b/src/Abstract/ObjectHandle.jl
@@ -124,7 +124,7 @@ function readmeta(io::IO)
         try
             return readmeta(io, T)
         catch e
-            if !isa(e,MagicMismatch)
+            if !isa(e,MagicMismatch) && !isa(e,EOFError)
                 rethrow(e)
             end
         end


### PR DESCRIPTION
This fixes the rather embarrassing issue of throwing on attempting to `readmeta()` an empty file